### PR TITLE
Rewrite install.sh with idempotent macOS installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,102 @@
 #!/bin/bash
+set -euo pipefail
 
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info() {
+  printf "${BLUE}[...]${NC} %s\n" "$1"
+}
+
+success() {
+  printf "${GREEN}[OK]${NC}  %s\n" "$1"
+}
+
+error() {
+  printf "${RED}[ERR]${NC} %s\n" "$1"
+}
+
+link_file() {
+  local src="$1"
+  local dest="$2"
+
+  if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$src" ]; then
+    success "$dest (already linked)"
+    return
+  fi
+
+  mkdir -p "$(dirname "$dest")"
+
+  if [ -e "$dest" ]; then
+    mv "$dest" "${dest}.backup"
+    info "Backed up $dest to ${dest}.backup"
+  fi
+
+  ln -s "$src" "$dest"
+  success "$dest -> $src"
+}
+
+# ---
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  error "This script only supports macOS"
+  exit 1
+fi
+
+echo ""
+echo "=== Dotfiles Installer ==="
+echo ""
+
+# 1. Homebrew
+info "Checking Homebrew..."
 if ! command -v brew > /dev/null; then
+  info "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
 
-if command -v brew > /dev/null; then
-  brew update
-  brew install zsh git wget
-  brew install --cask drawio rectangle tower netnewswire
-  brew install --build-from-source terraform
+  if [ -d "/opt/homebrew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
 fi
+success "Homebrew installed"
 
-git config --global user.email "francois.rousselet@rslt.fr"
+info "Updating Homebrew..."
+brew update
+success "Homebrew updated"
+
+# 2. CLI packages
+info "Installing CLI packages..."
+brew install zsh git wget
+success "CLI packages installed"
+
+# 3. Cask apps
+info "Installing cask apps..."
+brew install --cask drawio rectangle tower netnewswire
+success "Cask apps installed"
+
+# 4. Symlinks
+echo ""
+info "Creating symlinks..."
+link_file "$DOTFILES_DIR/zsh/.zshrc" "$HOME/.zshrc"
+link_file "$DOTFILES_DIR/htop/htoprc" "$HOME/.config/htop/htoprc"
+
+# 5. Git config
+echo ""
+info "Configuring git..."
 git config --global user.name "François Rousselet"
+git config --global user.email "francois.rousselet@rslt.fr"
+success "Git configured"
 
-cd /home/$USER
+# 6. Zsh extension directories
+info "Creating zsh extension directories..."
+mkdir -p "$HOME/.zsh_extra/pre"
+mkdir -p "$HOME/.zsh_extra/post"
+success "Zsh extension directories ready"
 
-# git clone https://github.com/frousselet/dotfiles.git .dotfiles
-rm -rf .zshrc
-ln -s .dotfiles/.zshrc .zshrc
-
-ln -s /Users/$USER/Library/Mobile\ Documents/com\~apple\~CloudDocs/Projets Projets
+echo ""
+echo "=== Done ==="
+echo ""


### PR DESCRIPTION
Replace the minimal install script with a proper setup script that:
- Checks for macOS before running
- Auto-detects the dotfiles directory
- Installs Homebrew, CLI packages, and cask apps
- Creates idempotent symlinks with backup of existing files
- Configures git and creates zsh extension directories
- Provides colored output for each step

https://claude.ai/code/session_015BBkXRjnGi1kitQGV4sfnU